### PR TITLE
Use author name and email from global gitconfig for initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Fixed
+### Updated
 
 - Initial commit will use system git user and email as author.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-* Nothing yet!
+### Fixed
+
+- Initial commit will use system git user and email as author.
 
 ## [0.13.0] - 01/27/2022
 

--- a/Craftsman/Helpers/Utilities.cs
+++ b/Craftsman/Helpers/Utilities.cs
@@ -78,7 +78,7 @@
         {
             return entityPlural;
         }
-        
+
         public static string GetWebHostFactoryName()
         {
             return "TestingWebApplicationFactory";
@@ -108,7 +108,7 @@
         {
             return "SwaggerServiceExtension";
         }
-        
+
         public static string GetAppSettingsName(bool asJson = true)
         {
             return asJson ? $"appsettings.json" : $"appsettings";
@@ -188,7 +188,7 @@
         {
             return $"Fake{objectToFakeName}";
         }
-        
+
         public static string FakeParentTestHelpers(Entity entity, out string fakeParentIdRuleFor)
         {
             var fakeParent = "";
@@ -210,7 +210,7 @@
 
             return fakeParent;
         }
-        
+
         public static string FakeParentTestHelpersTwoCount(Entity entity, out string fakeParentIdRuleForOne, out string fakeParentIdRuleForTwo)
         {
             var fakeParent = "";
@@ -236,8 +236,8 @@
 
             return fakeParent;
         }
-        
-        
+
+
         public static string FakeParentTestHelpersThreeCount(Entity entity, out string fakeParentIdRuleForOne, out string fakeParentIdRuleForTwo, out string fakeParentIdRuleForThree)
         {
             var fakeParent = "";
@@ -395,10 +395,10 @@ using {parentClassPath.ClassNamespace};";
             IFileSystem fileSystem)
         {
             AppSettingsBuilder.CreateWebApiAppSettings(solutionDirectory, dbName, projectBaseName);
-            
+
             if (environments.Where(e => e.EnvironmentName == "Development").Count() == 0)
                 environments.Add(new ApiEnvironment { EnvironmentName = "Development", ProfileName = $"{projectName} (Development)" });
-            
+
             foreach (var env in environments)
             {
                 WebApiLaunchSettingsModifier.AddProfile(solutionDirectory, env, port, projectBaseName);
@@ -429,7 +429,7 @@ using {parentClassPath.ClassNamespace};";
             string[] allFiles = Directory.GetFiles(solutionDirectory, "*.*", SearchOption.AllDirectories);
             Commands.Stage(repo, allFiles);
 
-            var author = new Signature("Craftsman", "craftsman", DateTimeOffset.Now);
+            var author = repo.Config.BuildSignature(DateTimeOffset.Now);
             repo.Commit("Initial Commit", author, author);
         }
 
@@ -520,7 +520,7 @@ using {parentClassPath.ClassNamespace};";
 
             if ((prop.Type.IsGuidPropertyType() && !prop.Type.Contains("?") && !prop.IsForeignKey))
                 return !string.IsNullOrEmpty(defaultValue) ? @$" = Guid.Parse(""{defaultValue}"");" : "";
-            
+
             return string.IsNullOrEmpty(defaultValue) ? "" : $" = {defaultValue};";
         }
 
@@ -588,7 +588,7 @@ using {parentClassPath.ClassNamespace};";
                     }
                 });
         }
-        
+
         public static string CreateApiRouteClasses(Entity entity)
         {
             var entityRouteClasses = "";


### PR DESCRIPTION
Currently the initial commit uses a default author and email. This causes commits to get rejected when a repo in GitHub has strict commit author / email checks enabled. Fix this by pulling the global gitconfig author for the initial commit. See [libgit2 tests](https://github.com/libgit2/libgit2sharp/blob/df3b22a754ef56da8d7e3c330ce2d783c2b7982e/LibGit2Sharp.Tests/CommitFixture.cs#L563)