### PR TITLE
Bugfix, Change AddProducerCommand to AddMessageCommand

### DIFF
--- a/Craftsman/Program.cs
+++ b/Craftsman/Program.cs
@@ -124,13 +124,13 @@ app.Configure(config =>
             .WithExample(new[] { "add producer", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.yml" })
             .WithExample(new[] { "add producer", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.json" });
 
-        add.AddCommand<AddProducerCommand>("message")
+        add.AddCommand<AddMessageCommand>("message")
             .WithAlias("messages")
             .WithDescription(
                 "Adds one or more messages to your Shared Kernel project using a formatted yaml or json file.")
-            .WithExample(new[] { "add producer", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.yaml" })
-            .WithExample(new[] { "add producer", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.yml" })
-            .WithExample(new[] { "add producer", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.json" });
+            .WithExample(new[] { "add message", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.yaml" })
+            .WithExample(new[] { "add message", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.yml" })
+            .WithExample(new[] { "add message", $"my{Path.DirectorySeparatorChar}file{Path.DirectorySeparatorChar}path.json" });
 
         add.AddBranch("next", next =>
         {


### PR DESCRIPTION
Noticed `craftsman add message` failed.

The `add.AddCommand<AddProducerCommand>("message")` was probably copy+paste error.

Changed 
`add.AddCommand<AddProducerCommand>("message")`

to
`add.AddCommand<AddMessageCommand>("message")`

and fixed example texts
