### PR TITLE
Update Pulumi.Keycloak version, using image from keycloak.org docs

### DIFF
--- a/Craftsman/Builders/AuthServer/PulumiYamlBuilders.cs
+++ b/Craftsman/Builders/AuthServer/PulumiYamlBuilders.cs
@@ -19,10 +19,10 @@ public class PulumiYamlBuilders
         _utilities.CreateFile(classPath, fileText);
     }
 
-    public void CreateDevConfig(string solutionDirectory, string projectBaseName, int? port, string username, string password)
+    public void CreateDevConfig(string solutionDirectory, string projectBaseName, int? port, string admin, string adminPassword)
     {
         var classPath = ClassPathHelper.AuthServerProjectRootClassPath(solutionDirectory, "Pulumi.dev.yaml", projectBaseName);
-        var fileText = GetDevConfigText(port, username, password);
+        var fileText = GetDevConfigText(port, admin, adminPassword);
         _utilities.CreateFile(classPath, fileText);
     }
 
@@ -34,13 +34,13 @@ description: Local setup for {projectBaseName}
 ";
     }
 
-    private static string GetDevConfigText(int? port, string username, string password)
+    private static string GetDevConfigText(int? port, string admin, string adminPassword)
     {
         return @$"config:
   keycloak:url: http://localhost:{port}
   keycloak:clientId: admin-cli
-  keycloak:username: {username}
-  keycloak:password: {password}
+  keycloak:username: {admin}
+  keycloak:password: {adminPassword}
 ";
     }
 }

--- a/Craftsman/Builders/Docker/DockerComposeBuilders.cs
+++ b/Craftsman/Builders/Docker/DockerComposeBuilders.cs
@@ -333,7 +333,7 @@ volumes:
       - keycloak-data:/var/lib/postgresql/data
   
   keycloak:
-    image: sleighzy/keycloak:latest
+    image: quay.io/keycloak/keycloak:latest
     environment:
       DB_VENDOR: POSTGRES
       DB_ADDR: keycloakdb
@@ -344,6 +344,8 @@ volumes:
       KEYCLOAK_USER: {template.Username}
       KEYCLOAK_PASSWORD: {template.Password}
       KEYCLOAK_HTTP_PORT: 8080
+      KEYCLOAK_ADMIN: {template.Admin}
+      KEYCLOAK_ADMIN_PASSWORD: {template.AdminPassword}
       # Uncomment the line below if you want to specify JDBC parameters. The parameter below is just an example, 
       # and it shouldn't be used in production without knowledge. It is highly recommended that you read the 
       # PostgreSQL JDBC driver documentation in order to use it.
@@ -352,6 +354,9 @@ volumes:
       - {template.Port}:8080
     depends_on:
       - keycloakdb
+    command:
+      - start-dev
+      - --features admin-fine-grained-authz
 ";
 
         var classPath = ClassPathHelper.SolutionClassPath(solutionDirectory, $"docker-compose.yaml");

--- a/Craftsman/Builders/Projects/AuthServerProjBuilder.cs
+++ b/Craftsman/Builders/Projects/AuthServerProjBuilder.cs
@@ -31,7 +31,7 @@ public class AuthServerProjBuilder
 
   <ItemGroup>
     <PackageReference Include=""Pulumi"" Version=""3.*"" />
-    <PackageReference Include=""Pulumi.Keycloak"" Version=""4.11.0"" />
+    <PackageReference Include=""Pulumi.Keycloak"" Version=""5.2.1"" />
   </ItemGroup>
 
 </Project>";

--- a/Craftsman/Commands/AddAuthServerCommand.cs
+++ b/Craftsman/Commands/AddAuthServerCommand.cs
@@ -73,7 +73,7 @@ public class AddAuthServerCommand : Command<AddAuthServerCommand.Settings>
 
                 var pulumiYamlBuilder = new PulumiYamlBuilders(_utilities);
                 pulumiYamlBuilder.CreateBaseFile(solutionDirectory, projectBaseName);
-                pulumiYamlBuilder.CreateDevConfig(solutionDirectory, projectBaseName, template.Port, template.Username, template.Password);
+                pulumiYamlBuilder.CreateDevConfig(solutionDirectory, projectBaseName, template.Port, template.Admin, template.AdminPassword);
 
                 new Builders.AuthServer.ProgramBuilder(_utilities).CreateAuthServerProgram(solutionDirectory, projectBaseName);
         

--- a/Craftsman/Domain/AuthServerTemplate.cs
+++ b/Craftsman/Domain/AuthServerTemplate.cs
@@ -26,6 +26,10 @@ public class AuthServerTemplate
 
     public string Password { get; set; } = "admin";
 
+    public string Admin { get; set; } = "superadmin";
+
+    public string AdminPassword { get; set; } = "superadmin";
+
     public List<AuthClient> Clients { get; set; } = new List<AuthClient>();
 
     /// <summary>


### PR DESCRIPTION
docker-compose with admin settings, pulumi settings...

Was unable to run and configure KeycloakPulumi project with Oidc2 settings.

Updated docker-compose-yaml with keycloak image taken from https://www.keycloak.org/server/containers documentation. (No more emulation on AMD64, but the image sleighzy/keycloak:latest might still work for those that need ARM)

This version have KEYCLOAK_ADMIN and KEYCLOAK_ADMIN_PASSWORD as environment variables input. They are reproduced in some of the Builders. (Maybe not all of them, what I could find).

When Pulumi.Keycloak runs, it uses the admin_cli from settings, and that one needs to match KEYCLOAK_ADMIN.

These changes needs some Documentation updates https://wrapt.dev/docs/auth-server-template#add-auth-server-template-properties
